### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -146,6 +150,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of Super Mario War, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the `unix` branch of `Makefile.libretro` is arch-neutral, there is no x86-specific code, and `android-arm64-v8a` and `osx-arm64` already build these sources for ARM64.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include. `GIT_SUBMODULE_STRATEGY: recursive` from `.core-defs` applies unchanged.

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 Chromebook, glibc): `make -f Makefile.libretro platform=unix` builds and links the complete core with no source changes - `superbroswar_libretro.so`, ELF 64-bit ARM aarch64. I didn't run a match on it (that needs the Super Mario War data package, which I don't have here), so this is a build verification.

One thing worth flagging while I was at it, unrelated to ARM: with GCC 14 or newer the build stops at `dependencies/SDL/src/audio/libretro/SDL_libretroaudio.c:158`, which passes `audio->hidden->mixbuf` (a `Uint8 *`) to `libretro_audio_cb(int16_t *, uint32_t)`. `-Wincompatible-pointer-types` became a hard error in GCC 14, so this only builds today because the buildbot images are on GCC 12 - I had to add `-Wno-incompatible-pointer-types` locally to get through it. It'll bite as soon as the images move to a newer compiler; a cast (or fixing the shim's prototype) would future-proof it. Happy to send that as a separate PR.
